### PR TITLE
Quote attribute values

### DIFF
--- a/bak.index.html
+++ b/bak.index.html
@@ -37,7 +37,7 @@
 
 <P><SMALL><A HREF="table.html">List of all entries</A></SMALL>
 
-<P><A HREF="../home/index.html"><DIV ALIGN=right><IMG SRC="home.gif" ALT="back to top" BORDER=0 HEIGHT=45 WIDTH=34></A></DIV>
+<P><A HREF="../home/index.html"><DIV ALIGN="right"><IMG SRC="home.gif" ALT="back to top" BORDER="0" HEIGHT="45" WIDTH="34"></A></DIV>
 
 </FONT>
 </TD>


### PR DESCRIPTION
The venerable www.w3schools.com recommends quoting all attribute values, even if they don't contain spaces:

> Using quotes are the most common. Omitting quotes can produce errors. At W3Schools we always use quotes around attribute values.

- https://www.w3schools.com/html/html_attributes.asp